### PR TITLE
use uint8_t instead of char for buffer

### DIFF
--- a/rosidl_typesupport_opensplice_c/resource/msg__type_support_c.cpp.em
+++ b/rosidl_typesupport_opensplice_c/resource/msg__type_support_c.cpp.em
@@ -597,7 +597,7 @@ serialize(
 
 static const char *
 deserialize(
-  const char * buffer,
+  const uint8_t * buffer,
   unsigned length,
   void * untyped_ros_message)
 {

--- a/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/message_type_support.h
+++ b/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/message_type_support.h
@@ -48,7 +48,7 @@ typedef struct message_type_support_callbacks_t
     void * untyped_serialized_message);
   const char *
   (*deserialize)(
-    const char * buffer,
+    const uint8_t * buffer,
     unsigned length,
     void * ros_message);
   // Functions for converting between DDS and ROS messages of this type.

--- a/rosidl_typesupport_opensplice_cpp/resource/msg__rosidl_typesupport_opensplice_cpp.hpp.em
+++ b/rosidl_typesupport_opensplice_cpp/resource/msg__rosidl_typesupport_opensplice_cpp.hpp.em
@@ -84,7 +84,7 @@ serialize__@(spec.base_type.type)(
 ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_EXPORT_@(spec.base_type.pkg_name)
 const char *
 deserialize__@(spec.base_type.type)(
-  const char * buffer,
+  const uint8_t * buffer,
   unsigned length,
   void * untyped_ros_message);
 

--- a/rosidl_typesupport_opensplice_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_opensplice_cpp/resource/msg__type_support.cpp.em
@@ -433,7 +433,7 @@ serialize__@(spec.base_type.type)(
 ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_EXPORT_@(spec.base_type.pkg_name)
 const char *
 deserialize__@(spec.base_type.type)(
-  const char * buffer,
+  const uint8_t * buffer,
   unsigned length,
   void * untyped_ros_message)
 {


### PR DESCRIPTION
that should fix the latest changes in the `rmw_serialized_message_t` to use `uint8_t` instead of `char`.

see https://github.com/ros2/rmw_opensplice/pull/247#issuecomment-441852524